### PR TITLE
Add filter hook to allow customization of language list

### DIFF
--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -62,5 +62,20 @@ function parse_wp_dropdown_languages()
 		}
 	}
 
-	return $languages;
+	/**
+	 * Filter the parsed languages array.
+	 *
+	 * Allows modifying the list of languages displayed in the admin bar.
+	 * Each language entry is an array with 'value' (locale code) and 'title' (display name).
+	 *
+	 * @since 2.1.0
+	 *
+	 * @param array $languages {
+	 *     The languages array.
+	 *
+	 *     @type array $active    The currently active language ('value' and 'title').
+	 *     @type array $available List of available languages, each with 'value' and 'title'.
+	 * }
+	 */
+	return apply_filters('salc_languages', $languages);
 }


### PR DESCRIPTION
## Summary
Added a new filter hook `salc_languages` to the `parse_wp_dropdown_languages()` function, allowing developers to customize the parsed languages array before it's returned.

## Key Changes
- Wrapped the return statement with `apply_filters('salc_languages', $languages)` to enable filtering
- Added comprehensive PHPDoc documentation for the new filter hook, including:
  - Description of the filter's purpose
  - Structure of the languages array parameter
  - Since version annotation (2.1.0)
  - Details about the array structure with 'active' and 'available' language entries

## Implementation Details
The filter is applied at the end of the function, allowing developers to modify the complete languages array after all parsing is complete. Each language entry contains 'value' (locale code) and 'title' (display name) keys, which are documented in the filter's PHPDoc block.

https://claude.ai/code/session_01MSWrhjLdzVntCML1p2Nbwn