### PR TITLE
Security: validate locale input, escape admin bar output, guard direct file access

### DIFF
--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -10,6 +10,11 @@
 
 namespace SALC;
 
+// If this file is called directly, abort.
+if (! defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Parse HTML of wp_dropdown_languages into array
  *

--- a/inc/scripts-and-styles.php
+++ b/inc/scripts-and-styles.php
@@ -10,6 +10,11 @@
 
 namespace SALC;
 
+// If this file is called directly, abort.
+if (! defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Add custom icon to the admin bar
  * https://wordpress.stackexchange.com/questions/172939/how-do-i-add-an-icon-to-a-new-admin-bar-item

--- a/inc/upgrade.php
+++ b/inc/upgrade.php
@@ -10,6 +10,11 @@
 
 namespace SALC;
 
+// If this file is called directly, abort.
+if (! defined('ABSPATH')) {
+	exit;
+}
+
 /**
  * Check version and run upgrade routine if needed.
  *

--- a/simple-admin-language-change.php
+++ b/simple-admin-language-change.php
@@ -67,7 +67,7 @@ function admin_menu($admin_bar)
 		'id'    => 'salc-current-language',
 		'parent' => 'top-secondary',
 		'group'  => null,
-		'title' => '<span class="ab-icon"></span>' . $languages['active']['title'],
+		'title' => '<span class="ab-icon"></span>' . esc_html($languages['active']['title']),
 		'href'  => '#',
 		'meta' => [
 			'title' => __('Current dashboard language', 'simple-admin-language-change'),
@@ -80,7 +80,7 @@ function admin_menu($admin_bar)
 			'id'    => 'salc-current-' . sanitize_title($la['title']),
 			'parent' => 'salc-current-language',
 			'group'  => null,
-			'title' => $la['title'],
+			'title' => esc_html($la['title']),
 			'href' => '#' . ($la['value'] ? $la['value'] : 'en_US'),
 		]);
 	}
@@ -102,9 +102,10 @@ function change_user_locale_ajax()
 	}
 
 
-	// Check for permissions and if it is admin.
-	if (! current_user_can('read') || ! is_admin()) {
-
+	// Check for permissions. Note that is_admin() is always true for
+	// admin-ajax.php requests, so the capability check and the nonce
+	// above are the effective gates here.
+	if (! current_user_can('read')) {
 		wp_die(esc_html(__('You don\'t have the correct permissions for language change.', 'simple-admin-language-change')));
 	}
 
@@ -113,17 +114,18 @@ function change_user_locale_ajax()
 	$lang = isset($_REQUEST['lang']) ? \sanitize_text_field(wp_unslash($_REQUEST['lang'])) : false;
 
 	if (! $user_id || ! $lang) {
-		\wp_send_json_error('updated', 403);
-		wp_die();
+		\wp_send_json_error('missing locale', 400);
 	}
 
 	if ($lang === 'site-default') {
-		$lang = null;
+		$lang = '';
+	} elseif ($lang !== 'en_US' && ! in_array($lang, get_available_languages(), true)) {
+		// Only installed locales may be stored, mirroring core's edit_user().
+		\wp_send_json_error('invalid locale', 400);
 	}
 
 	wp_update_user(['ID' => $user_id, 'locale' => $lang]);
 
 	\wp_send_json_success('updated', 200);
-	wp_die();
 }
 add_action("wp_ajax_change_user_locale", __NAMESPACE__ . "\change_user_locale_ajax");


### PR DESCRIPTION
Security fixes from the deep review (PR 1 of 3).

## Changes

- **Validate the AJAX `lang` parameter against installed locales.** `wp_update_user()` does not validate `locale` itself (core only validates in `edit_user()` when the profile form is submitted), so any logged-in user could store an arbitrary string — including path-traversal-shaped values like `../../foo`, which `sanitize_text_field()` does not strip — in their `locale` user meta. That value later flows into translation file paths such as `WP_LANG_DIR . "/admin-$locale.mo"`. The handler now accepts only `site-default`, `en_US`, or a locale returned by `get_available_languages()`, mirroring core's `edit_user()`.
- **Escape language titles rendered into admin bar nodes.** `DOMDocument::$nodeValue` decodes the entity escaping applied by `wp_dropdown_languages()`, and titles also pass through the public `salc_languages` filter, so they are now run through `esc_html()`. Note for filter users: HTML in `title` values is no longer rendered.
- **Add `ABSPATH` guards to the `inc/*.php` files** to prevent direct file access (previously `scripts-and-styles.php` executed `add_action()` at file scope and fataled, which can disclose paths when `display_errors` is on).
- **AJAX handler cleanup:** removed the `is_admin()` check, which is always true for `admin-ajax.php` requests and only gave a false sense of restriction (the nonce + capability check are the real gates); invalid input now returns HTTP 400 with an accurate message instead of `403`/`'updated'`; dropped dead `wp_die()` calls after `wp_send_json_*()`, which already terminate.

## Behavior notes

- `site-default` is now stored as `''` instead of `null` — `wp_insert_user()` normalizes both to `''`, so the stored meta is identical.
- Users can still only change **their own** locale (`get_current_user_id()`), same as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VPGXS7M1UYdJJvH62Vydb2

---
_Generated by [Claude Code](https://claude.ai/code/session_01VPGXS7M1UYdJJvH62Vydb2)_