### PR TITLE
Performance: cache language list, tighten asset loading, fix textdomain path

### DIFF
--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -20,46 +20,57 @@ function parse_wp_dropdown_languages()
 
 	$user_locale = get_user_locale();
 	$available_languages = get_available_languages();
-	ob_start();
-	wp_dropdown_languages(
-		[
-			'name'                        => 'locale',
-			'id'                          => 'locale',
-			'selected'                    => $user_locale,
-			'languages'                   => $available_languages,
-			'show_available_translations' => false,
-			'show_option_site_default'    => true,
-		]
-	);
-	$wp_dropdown_languages = ob_get_contents();
-	ob_end_clean();
-	$languages = [
-		'active' => [],
-		'available' => []
-	];
 
-	$dom = new \DOMDocument();
+	// Rendering the dropdown calls wp_get_available_translations(), which may
+	// perform a blocking HTTP request to api.wordpress.org, and parsing it
+	// back out of the HTML is costly, so the result is cached. The key changes
+	// whenever the user locale or the set of installed languages changes.
+	$cache_key = 'salc_languages_' . md5(SALC_VERSION . '|' . $user_locale . '|' . implode(',', $available_languages));
+	$languages = get_transient($cache_key);
 
-	// If the content contains HTML entities, convert them to ensure proper display.
-	if (version_compare(phpversion(), '8.2', '>=')) {
-		$content = mb_encode_numericentity(htmlspecialchars_decode(htmlentities($wp_dropdown_languages, ENT_NOQUOTES, 'UTF-8', false), ENT_NOQUOTES), [0x80, 0x10FFFF, 0, ~0], 'UTF-8');
-	} else {
-		$content = mb_convert_encoding($wp_dropdown_languages, 'HTML-ENTITIES', 'UTF-8');
-	}
-
-	$dom->loadHTML($content);
-	
-	$options = $dom->getElementsByTagName('option');
-	for ($i = 0; $i < $options->length; $i++) {
-		$language = [
-			'value' => $options->item($i)->getAttribute('value'),
-			'title' => $options->item($i)->nodeValue,
+	if (! is_array($languages) || ! isset($languages['active'], $languages['available'])) {
+		ob_start();
+		wp_dropdown_languages(
+			[
+				'name'                        => 'locale',
+				'id'                          => 'locale',
+				'selected'                    => $user_locale,
+				'languages'                   => $available_languages,
+				'show_available_translations' => false,
+				'show_option_site_default'    => true,
+			]
+		);
+		$wp_dropdown_languages = ob_get_clean();
+		$languages = [
+			'active' => [],
+			'available' => []
 		];
-		if ($options->item($i)->hasAttribute('selected')) {
-			$languages['active'] = $language;
+
+		$dom = new \DOMDocument();
+
+		// If the content contains HTML entities, convert them to ensure proper display.
+		if (version_compare(phpversion(), '8.2', '>=')) {
+			$content = mb_encode_numericentity(htmlspecialchars_decode(htmlentities($wp_dropdown_languages, ENT_NOQUOTES, 'UTF-8', false), ENT_NOQUOTES), [0x80, 0x10FFFF, 0, ~0], 'UTF-8');
 		} else {
-			$languages['available'][] = $language;
+			$content = mb_convert_encoding($wp_dropdown_languages, 'HTML-ENTITIES', 'UTF-8');
 		}
+
+		$dom->loadHTML($content);
+
+		$options = $dom->getElementsByTagName('option');
+		for ($i = 0; $i < $options->length; $i++) {
+			$language = [
+				'value' => $options->item($i)->getAttribute('value'),
+				'title' => $options->item($i)->nodeValue,
+			];
+			if ($options->item($i)->hasAttribute('selected')) {
+				$languages['active'] = $language;
+			} else {
+				$languages['available'][] = $language;
+			}
+		}
+
+		set_transient($cache_key, $languages, DAY_IN_SECONDS);
 	}
 
 	/**

--- a/inc/scripts-and-styles.php
+++ b/inc/scripts-and-styles.php
@@ -18,6 +18,9 @@ namespace SALC;
  */
 function admin_css()
 {
+	if (! is_admin_bar_showing()) {
+		return;
+	}
 	echo '<style>
     #wpadminbar #wp-admin-bar-salc-current-language .ab-icon:before {
 		content: "\f326";
@@ -36,12 +39,12 @@ add_action('admin_head', __NAMESPACE__ . '\admin_css');
 function load_script($hook_suffix)
 {
 
-	// Check for permissions and if it is admin.
-	if (! current_user_can('read') || ! is_admin() ) {
+	// Check for permissions and bail when the admin bar is not rendered.
+	if (! current_user_can('read') || ! is_admin_bar_showing() ) {
 		return;
 	}
-	wp_enqueue_script('salc', plugin_dir_url(dirname(__FILE__)) . '/script.js', [], \SALC_VERSION, true);
-	wp_localize_script('salc', 'props', [
+	wp_enqueue_script('salc', plugin_dir_url(dirname(__FILE__)) . 'script.js', [], \SALC_VERSION, true);
+	wp_localize_script('salc', 'salcProps', [
 		'ajax_url' => admin_url('admin-ajax.php'),
 		'nonce' => wp_create_nonce("salc_change_user_locale")
 	]);

--- a/script.js
+++ b/script.js
@@ -7,11 +7,11 @@ window.addEventListener('load', () => {
 
 function salc_change_admin_language(e) {
 
-    e.preventDefault;
+    e.preventDefault();
     var language = this.getAttribute("href").substring(1);
     var request = new XMLHttpRequest();
 
-    request.open('POST', props.ajax_url, true);
+    request.open('POST', salcProps.ajax_url, true);
     request.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded;');
 
     request.onload = function () {
@@ -26,7 +26,5 @@ function salc_change_admin_language(e) {
         }
     };
 
-    request.send('action=change_user_locale&nonce=' + props.nonce + '&lang=' + language);
-
-    return false;
+    request.send('action=change_user_locale&nonce=' + encodeURIComponent(salcProps.nonce) + '&lang=' + encodeURIComponent(language));
 }

--- a/simple-admin-language-change.php
+++ b/simple-admin-language-change.php
@@ -39,7 +39,7 @@ define('SALC_VERSION', '2.1.0');
  */
 function localize_plugin()
 {
-	load_plugin_textdomain('simple-admin-language-change', false, plugin_dir_path(__FILE__) . 'languages/');
+	load_plugin_textdomain('simple-admin-language-change', false, dirname(plugin_basename(__FILE__)) . '/languages/');
 }
 add_action('init', __NAMESPACE__ . '\localize_plugin');
 


### PR DESCRIPTION
Performance and JS robustness fixes from the deep review (PR 2 of 3).

## Changes

- **Cache the parsed language array in a transient** (`DAY_IN_SECONDS`, keyed by plugin version + user locale + installed languages, so it self-invalidates when a language is installed/removed or the user switches locale). Rendering `wp_dropdown_languages()` calls `wp_get_available_translations()`, which performs a **blocking HTTP request to api.wordpress.org** whenever core's 3-hour transient is cold — and on firewalled/intranet hosts that can't reach the API, the failed response is never cached, so *every* admin page load blocked for the full HTTP timeout. The output-buffer + `DOMDocument` parse also no longer runs on every admin page view.
- **Only load assets when the admin bar is rendered:** `script.js` enqueue and the inline admin bar CSS now bail on `is_admin_bar_showing()` (skips iframe/JSON requests where the bar never appears).
- **Fix `load_plugin_textdomain()` path:** the third argument must be relative to the plugins directory; the absolute path made the bundled-translations lookup fail on every request (it only worked via the wordpress.org language-pack fallback).
- **Fix double slash** in the enqueued script URL (`…plugin-dir//script.js`).
- **Rename the `props` JS global to `salcProps`** — the generic name is easily clobbered by another plugin localizing its own `props`.
- **script.js:** actually call `e.preventDefault()` (the call parentheses were missing and `return false` does nothing in an `addEventListener` handler, so clicks mutated the URL hash), and URL-encode the POST body values.

## Notes

- On a cold cache the first admin-bar render per user-locale/day still builds the list the same way as before; every subsequent render is a single transient read.
- Trade-off: if the translations API is unreachable during a cold-cache build, locale codes (rather than native names) may be cached for up to a day — previously that degraded state occurred on every page load along with the timeout.
- Merges cleanly with #9 (they touch different regions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VPGXS7M1UYdJJvH62Vydb2

---
_Generated by [Claude Code](https://claude.ai/code/session_01VPGXS7M1UYdJJvH62Vydb2)_