### PR TITLE
CI: pin actions to commit SHAs, least-privilege permissions, portable sed

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,16 +2,20 @@ name: Deploy to WordPress.org
 on:
   release:
     types: [published]
+permissions:
+  contents: read
 jobs:
   tag:
     name: New release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # Needed to upload the release asset.
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
     - name: WordPress Plugin Deploy
       id: deploy
-      uses: 10up/action-wordpress-plugin-deploy@stable
+      uses: 10up/action-wordpress-plugin-deploy@54bd289b8525fd23a5c365ec369185f2966529c2 # 2.3.0
       with:
         generate-zip: true
       env:
@@ -19,11 +23,10 @@ jobs:
         SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
         SLUG: ${{ secrets.SLUG }}
     - name: Upload release asset
-      uses: actions/upload-release-asset@v1
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ github.event.release.upload_url }}
-        asset_path: ${{github.workspace}}/${{ secrets.SLUG }}.zip
-        asset_name: ${{ secrets.SLUG }}-${{github.event.release.tag_name}}.zip
-        asset_content_type: application/zip
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        TAG: ${{ github.event.release.tag_name }}
+        SLUG: ${{ secrets.SLUG }}
+      run: |
+        cp "${GITHUB_WORKSPACE}/${SLUG}.zip" "${RUNNER_TEMP}/${SLUG}-${TAG}.zip"
+        gh release upload "$TAG" "${RUNNER_TEMP}/${SLUG}-${TAG}.zip" --repo "$GITHUB_REPOSITORY"

--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -3,14 +3,16 @@ on:
   push:
     branches:
     - trunk
+permissions:
+  contents: read
 jobs:
   trunk:
     name: Push to trunk
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
     - name: WordPress.org plugin asset/readme update
-      uses: 10up/action-wordpress-plugin-asset-update@stable
+      uses: 10up/action-wordpress-plugin-asset-update@2480306f6f693672726d08b5917ea114cb2825f7 # 2.2.0
       env:
         SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
         SVN_USERNAME: ${{ secrets.SVN_USERNAME }}

--- a/bin/version-bump.sh
+++ b/bin/version-bump.sh
@@ -3,6 +3,15 @@
 PLUGIN_FILE="simple-admin-language-change.php"
 README_FILE="readme.txt"
 
+# In-place sed that works with both GNU sed (Linux) and BSD sed (macOS)
+sedi() {
+    if sed --version >/dev/null 2>&1; then
+        sed -i "$@"
+    else
+        sed -i '' "$@"
+    fi
+}
+
 # Function to increment version number
 increment_version() {
     local version=$1
@@ -44,12 +53,12 @@ fi
 echo ""
 
 # Update version in plugin header (preserve tabs/spaces)
-sed -i '' "s/\(Version:[[:space:]]*\)$header_version/\1$new_version/" "$PLUGIN_FILE"
+sedi "s/\(Version:[[:space:]]*\)$header_version/\1$new_version/" "$PLUGIN_FILE"
 echo "Updated plugin header to $new_version"
 
 # Update version constant
 if [ -n "$constant_version" ]; then
-    sed -i '' "s/SALC_VERSION', '$constant_version'/SALC_VERSION', '$new_version'/" "$PLUGIN_FILE"
+    sedi "s/SALC_VERSION', '$constant_version'/SALC_VERSION', '$new_version'/" "$PLUGIN_FILE"
     echo "Updated PHP constant to $new_version"
 fi
 
@@ -58,7 +67,7 @@ read -p "Update stable tag in readme.txt? (y/n): " update_readme
 
 if [ "$update_readme" = "y" ] || [ "$update_readme" = "Y" ]; then
     if [ -f "$README_FILE" ]; then
-        sed -i '' "s/^Stable tag: .*/Stable tag: $new_version/" "$README_FILE"
+        sedi "s/^Stable tag: .*/Stable tag: $new_version/" "$README_FILE"
         echo "Updated stable tag in readme.txt"
     else
         echo "readme.txt not found"


### PR DESCRIPTION
Supply-chain hardening for the deploy pipeline plus one tooling fix (PR 3 of 3).

## Changes

- **Pin the 10up actions to commit SHAs.** Both workflows ran `10up/…@stable`, a mutable branch, while handing the action your WordPress.org SVN credentials — if that ref were ever repointed to malicious code, the credentials could be exfiltrated and the distributed plugin trojaned. Pinned to the commits `stable` currently points to: deploy `54bd289` (= tag 2.3.0) and asset-update `2480306` (= tag 2.2.0). Dependabot/Renovate can keep these fresh if you enable it.
- **Replace deprecated checkouts:** `actions/checkout@v2` (end-of-life Node 16) and `actions/checkout@master` (mutable ref) → SHA-pinned v4.3.1.
- **Replace the archived `actions/upload-release-asset@v1`** with `gh release upload`, which is maintained and built into the runner. The tag name is passed via an env var rather than interpolated into the script, so a crafted tag name can't inject shell commands.
- **Add least-privilege `permissions:` blocks** to both workflows (`contents: read` default; `contents: write` only for the release-asset job).
- **`bin/version-bump.sh`:** the BSD-only `sed -i ''` form errors on Linux; replaced with a small `sedi()` wrapper that works with both GNU and BSD sed.

## Heads-up (not changed here)

`update-readme.yml` triggers on pushes to `trunk`, but this repository's default branch is `master` — as written, that workflow never fires. I left the trigger untouched since changing it would start pushing readme/asset updates to WordPress.org SVN on every master push; happy to flip it to `master` if that's the intent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VPGXS7M1UYdJJvH62Vydb2

---
_Generated by [Claude Code](https://claude.ai/code/session_01VPGXS7M1UYdJJvH62Vydb2)_